### PR TITLE
Remove the use of the now deprecated React.Proptypes and createJSModules method

### DIFF
--- a/RNDFPBanner.js
+++ b/RNDFPBanner.js
@@ -3,6 +3,7 @@ import {
   requireNativeComponent,
   View,
 } from 'react-native';
+import PropTypes from 'proptypes';
 
 const RNBanner = requireNativeComponent('RNDFPBanner', DFPBanner);
 
@@ -59,28 +60,28 @@ DFPBanner.propTypes = {
    *
    * banner is default
    */
-  bannerSize: React.PropTypes.string,
+  bannerSize: PropTypes.string,
 
   /**
    * AdMob ad unit ID
    */
-  adUnitID: React.PropTypes.string,
+  adUnitID: PropTypes.string,
 
   /**
    * Test device ID
    */
-  testDeviceID: React.PropTypes.string,
+  testDeviceID: PropTypes.string,
 
   /**
    * AdMob iOS library events
    */
-  adViewDidReceiveAd: React.PropTypes.func,
-  didFailToReceiveAdWithError: React.PropTypes.func,
-  adViewWillPresentScreen: React.PropTypes.func,
-  adViewWillDismissScreen: React.PropTypes.func,
-  adViewDidDismissScreen: React.PropTypes.func,
-  adViewWillLeaveApplication: React.PropTypes.func,
-  admobDispatchAppEvent: React.PropTypes.func,
+  adViewDidReceiveAd: PropTypes.func,
+  didFailToReceiveAdWithError: PropTypes.func,
+  adViewWillPresentScreen: PropTypes.func,
+  adViewWillDismissScreen: PropTypes.func,
+  adViewDidDismissScreen: PropTypes.func,
+  adViewWillLeaveApplication: PropTypes.func,
+  admobDispatchAppEvent: PropTypes.func,
   ...View.propTypes,
 };
 

--- a/android/src/main/java/com/reactlibrary/RNDfpPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNDfpPackage.java
@@ -19,11 +19,6 @@ public class RNDfpPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         List<ViewManager> managers = new ArrayList<>();
         managers.add(new RNDfpBannerViewManager());

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "peerDependencies": {
     "react-native": ">=0.40.0",
     "react-native-windows": "0.41.0-rc.1"
-
+  },
+  "dependencies": {
+    "proptypes": "^1.1.0"
   }
 }


### PR DESCRIPTION
On `react-native@0.49.*`, it now fails instead of giving a warning

Could be interesting to release that as a new major (`v1.0.0`) because it is kind of a breaking change