### PR TITLE
Use custom dimensions with RNBanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ import { RNBanner } from 'react-native-dfp';
   onAdmobDispatchAppEvent={(event) => admobDispatchAppEvent(event)}
   testDeviceID={testDeviceID}
   adUnitID={adUnitID}
+  dimensions={dimensions}
   bannerSize={bannerSize} />
 
 ```
@@ -86,6 +87,14 @@ import { RNBanner } from 'react-native-dfp';
  * banner is default
  */
 bannerSize: React.PropTypes.string,
+
+/**
+ * Custom banner size (instead of using bannerSize)
+ */
+dimensions: PropTypes.shape({
+  height: PropTypes.number,
+  width: PropTypes.number,
+}),
 
 /**
  * DFP ad unit ID

--- a/RNDFPBanner.js
+++ b/RNDFPBanner.js
@@ -24,14 +24,22 @@ export default class DFPBanner extends React.Component {
 
   render() {
     const { adUnitID, testDeviceID, dimensions, style, didFailToReceiveAdWithError, admobDispatchAppEvent } = this.props;
-    let { bannerSize } = this.props;
+    let { bannerSize, adSizes } = this.props;
 
-    if (!bannerSize && (!dimensions || !dimensions.width || !dimensions.height)) {
-      bannerSize = 'smartBannerPortrait';
+    // Dimensions gets highest priority
+    if (dimensions && dimensions.width && dimensions.height) {
+      bannerSize = undefined;
+      adSizes = undefined;
     }
 
-    if (bannerSize && dimensions && dimensions.width && dimensions.height) {
-      bannerSize = null;
+    // AdSizes gets second priority
+    if (adSizes && adSizes.length > 0) {
+      bannerSize = undefined;
+    }
+
+    // Default to something if nothing is set
+    if (!bannerSize && (!dimensions || !dimensions.width || !dimensions.height) && (!adSizes || !adSizes.length > 0)) {
+       bannerSize = 'smartBannerPortrait';
     }
 
     return (
@@ -46,6 +54,7 @@ export default class DFPBanner extends React.Component {
           onAdViewDidDismissScreen={this.props.adViewDidDismissScreen}
           onAdViewWillLeaveApplication={this.props.adViewWillLeaveApplication}
           onAdmobDispatchAppEvent={(event) => admobDispatchAppEvent(event)}
+          adSizes={adSizes}
           dimensions={dimensions}
           testDeviceID={testDeviceID}
           adUnitID={adUnitID}
@@ -80,6 +89,12 @@ DFPBanner.propTypes = {
     height: PropTypes.number,
     width: PropTypes.number,
   }),
+
+  /**
+   * Array of some combination of bannerSize and dimensions that are valid for the ad
+   * Example: ['mediumRectangle', { width: 320, height: 400 }, 'smartBannerPortrait']
+   */
+  adSizes: PropTypes.array,
 
   /**
    * AdMob ad unit ID

--- a/RNDFPBanner.js
+++ b/RNDFPBanner.js
@@ -23,7 +23,17 @@ export default class DFPBanner extends React.Component {
   }
 
   render() {
-    const { adUnitID, testDeviceID, bannerSize, style, didFailToReceiveAdWithError,admobDispatchAppEvent } = this.props;
+    const { adUnitID, testDeviceID, dimensions, style, didFailToReceiveAdWithError, admobDispatchAppEvent } = this.props;
+    let { bannerSize } = this.props;
+
+    if (!bannerSize && (!dimensions || !dimensions.width || !dimensions.height)) {
+      bannerSize = 'smartBannerPortrait';
+    }
+
+    if (bannerSize && dimensions && dimensions.width && dimensions.height) {
+      bannerSize = null;
+    }
+
     return (
       <View style={this.props.style}>
         <RNBanner
@@ -36,6 +46,7 @@ export default class DFPBanner extends React.Component {
           onAdViewDidDismissScreen={this.props.adViewDidDismissScreen}
           onAdViewWillLeaveApplication={this.props.adViewWillLeaveApplication}
           onAdmobDispatchAppEvent={(event) => admobDispatchAppEvent(event)}
+          dimensions={dimensions}
           testDeviceID={testDeviceID}
           adUnitID={adUnitID}
           bannerSize={bannerSize} />
@@ -63,6 +74,14 @@ DFPBanner.propTypes = {
   bannerSize: PropTypes.string,
 
   /**
+   * Custom banner size (instead of using bannerSize)
+   */
+  dimensions: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number,
+  }),
+
+  /**
    * AdMob ad unit ID
    */
   adUnitID: PropTypes.string,
@@ -86,7 +105,6 @@ DFPBanner.propTypes = {
 };
 
 DFPBanner.defaultProps = {
-    bannerSize: 'smartBannerPortrait',
     didFailToReceiveAdWithError: () => {},
     admobDispatchAppEvent: () => {}
 };

--- a/ios/RNDFPBannerManager.m
+++ b/ios/RNDFPBannerManager.m
@@ -21,6 +21,7 @@ RCT_EXPORT_MODULE();
     return dispatch_get_main_queue();
 }
 
+RCT_EXPORT_VIEW_PROPERTY(adSizes, NSArray);
 RCT_EXPORT_VIEW_PROPERTY(dimensions, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(bannerSize, NSString);
 RCT_EXPORT_VIEW_PROPERTY(adUnitID, NSString);

--- a/ios/RNDFPBannerManager.m
+++ b/ios/RNDFPBannerManager.m
@@ -21,6 +21,7 @@ RCT_EXPORT_MODULE();
     return dispatch_get_main_queue();
 }
 
+RCT_EXPORT_VIEW_PROPERTY(dimensions, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(bannerSize, NSString);
 RCT_EXPORT_VIEW_PROPERTY(adUnitID, NSString);
 RCT_EXPORT_VIEW_PROPERTY(testDeviceID, NSString);

--- a/ios/RNDFPBannerView.h
+++ b/ios/RNDFPBannerView.h
@@ -8,12 +8,15 @@
 
 @class RCTEventDispatcher;
 
-@interface RNDFPBannerView : UIView <GADBannerViewDelegate>
+@interface RNDFPBannerView : UIView <GADBannerViewDelegate, GADAdSizeDelegate>
 
+@property (nonatomic, copy) NSArray *adSizes;
 @property (nonatomic, copy) NSDictionary *dimensions;
 @property (nonatomic, copy) NSString *bannerSize;
 @property (nonatomic, copy) NSString *adUnitID;
 @property (nonatomic, copy) NSString *testDeviceID;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onWillChangeAdSizeTo;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAdmobDispatchAppEvent;

--- a/ios/RNDFPBannerView.h
+++ b/ios/RNDFPBannerView.h
@@ -10,6 +10,7 @@
 
 @interface RNDFPBannerView : UIView <GADBannerViewDelegate>
 
+@property (nonatomic, copy) NSDictionary *dimensions;
 @property (nonatomic, copy) NSString *bannerSize;
 @property (nonatomic, copy) NSString *adUnitID;
 @property (nonatomic, copy) NSString *testDeviceID;

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -51,8 +51,9 @@
 }
 
 -(void)loadBanner {
-    if (_adUnitID && (_bannerSize || _dimensions)) {
+    if (_adUnitID && (_bannerSize || _dimensions || _adSizes)) {
         GADAdSize size;
+        NSMutableArray *validAdSizes;
 
         if (_dimensions) {
             NSNumber *width = [RCTConvert NSNumber:_dimensions[@"width"]];
@@ -65,21 +66,71 @@
 
             size = GADAdSizeFromCGSize(cgSize);
         } else {
-            size = [self getAdSizeFromString:_bannerSize];
+            if (_adSizes) {
+                validAdSizes = [[NSMutableArray alloc] init];
+                for (id anAdSize in _adSizes) {
+                    GADAdSize aSize;
+
+                    // BannerSize
+                    if ([anAdSize isKindOfClass:[NSString class]]) {
+                        NSString *stringAdSize = (NSString *)anAdSize;
+
+                        aSize = [self getAdSizeFromString:stringAdSize];
+
+                        [validAdSizes addObject:NSValueFromGADAdSize(aSize)];
+
+                        // Set size to the first one in the list
+                        if (CGSizeEqualToSize(CGSizeFromGADAdSize(size), CGSizeMake(0.0, 0.0))) {
+                            size = aSize;
+                        }
+                    }
+
+                    // Dimensions
+                    if ([anAdSize isKindOfClass:[NSDictionary class]]) {
+                        NSDictionary *dictionaryAdSize = (NSDictionary *)anAdSize;
+
+                        NSNumber *width = [RCTConvert NSNumber:dictionaryAdSize[@"width"]];
+                        NSNumber *height = [RCTConvert NSNumber:dictionaryAdSize[@"height"]];
+
+                        CGFloat widthVal = [width doubleValue];
+                        CGFloat heightVal = [height doubleValue];
+
+                        CGSize cgSize = CGSizeMake(widthVal, heightVal);
+
+                        aSize = GADAdSizeFromCGSize(cgSize);
+
+                        [validAdSizes addObject:NSValueFromGADAdSize(aSize)];
+
+                        // Set size to the first one in the list
+                        if (CGSizeEqualToSize(CGSizeFromGADAdSize(size), CGSizeMake(0.0, 0.0))) {
+                            size = aSize;
+                        }
+                    }
+                }
+            } else {
+                size = [self getAdSizeFromString:_bannerSize];
+            }
         }
+
         _bannerView = [[DFPBannerView alloc] initWithAdSize:size];
         [_bannerView setAppEventDelegate:self]; //added Admob event dispatch listener
-        if(!CGRectEqualToRect(self.bounds, _bannerView.bounds)) {
+        // if(!CGRectEqualToRect(self.bounds, _bannerView.bounds)) {
             if (self.onSizeChange) {
                 self.onSizeChange(@{
                                     @"width": [NSNumber numberWithFloat: _bannerView.bounds.size.width],
                                     @"height": [NSNumber numberWithFloat: _bannerView.bounds.size.height]
                                     });
             }
-        }
+        // }
         _bannerView.delegate = self;
+        _bannerView.adSizeDelegate = self;
         _bannerView.adUnitID = _adUnitID;
         _bannerView.rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+
+        if (validAdSizes) {
+          _bannerView.validAdSizes = validAdSizes;
+        }
+
         GADRequest *request = [GADRequest request];
         if(_testDeviceID) {
             if([_testDeviceID isEqualToString:@"EMULATOR"]) {
@@ -101,6 +152,17 @@ didReceiveAppEvent:(NSString *)name
     myDictionary[name] = info;
     if (self.onAdmobDispatchAppEvent) {
         self.onAdmobDispatchAppEvent(@{ name: info });
+    }
+}
+
+- (void)setAdSizes:(NSArray *)adSizes
+{
+    if(![adSizes isEqual:_adSizes]) {
+        _adSizes = adSizes;
+        if (_bannerView) {
+            [_bannerView removeFromSuperview];
+        }
+        [self loadBanner];
     }
 }
 
@@ -162,6 +224,17 @@ didReceiveAppEvent:(NSString *)name
 - (void)removeFromSuperview
 {
     [super removeFromSuperview];
+}
+
+/// Called before the ad view changes to the new size.
+- (void)adView:(DFPBannerView *)bannerView
+willChangeAdSizeTo:(GADAdSize)size {
+    if (self.onWillChangeAdSizeTo) {
+        // bannerView calls this method on its adSizeDelegate object before the banner updates it size,
+        // allowing the application to adjust any views that may be affected by the new ad size.
+        self.onWillChangeAdSizeTo(@{});
+    }
+
 }
 
 /// Tells the delegate an ad request loaded an ad.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dfp",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "React Native bridge for Google DFP",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Added new prop `dimensions` to RNBanner, it's an object with a width and a height of the ad. 
- If dimensions and bannerSize are both used (for whatever reason), it uses dimensions
- If neither are passed, it falls back to bannerSize default